### PR TITLE
Ensure readme has up to date examples

### DIFF
--- a/src/copycat.test.ts
+++ b/src/copycat.test.ts
@@ -17,25 +17,6 @@ test('determinism', () => {
   Object.keys(copycat).forEach(check)
 })
 
-test('readme values', () => {
-  const results = {}
-
-  const addResult = (name: string) => {
-    results[name] = copycat[name]('foo')
-  }
-
-  Object.keys(copycat).forEach(addResult)
-
-  expect(results).toMatchInlineSnapshot(`
-    Object {
-      "email": "Liana_Hansen892@hotmail.com",
-      "firstName": "Nasir",
-      "fullName": "Liana Howell",
-      "lastName": "Langosh",
-    }
-  `)
-})
-
 test('generated values', () => {
   const count = 10
   const results = {}

--- a/src/readme.test.ts
+++ b/src/readme.test.ts
@@ -1,0 +1,52 @@
+import { readFile } from 'fs/promises'
+import path from 'path'
+import { inspect } from 'util'
+import { copycat } from '.'
+
+expect.extend({
+  toHaveUpToDateExamples(source, results: { [s: string]: unknown }) {
+    const missingResults = []
+
+    for (const name of Object.keys(results)) {
+      const value = inspect(results[name], { depth: 10 })
+
+      if (!source.includes(value)) {
+        missingResults.push({
+          name,
+          value,
+        })
+      }
+    }
+
+    if (missingResults.length) {
+      return {
+        message: () =>
+          [
+            'Expected the following API methods to have examples, but could not find them. Are they in the readme and up to date?',
+            ...missingResults.map(({ name, value }) => `* ${name}: ${value}`),
+          ].join('\n'),
+        pass: false,
+      }
+    }
+
+    return {
+      message: () => 'Expected missing examples in readme',
+      pass: true,
+    }
+  },
+})
+
+test('readme examples are up to date', async () => {
+  const readmeSource = (
+    await readFile(path.join(__dirname, '..', 'README.md'))
+  ).toString()
+
+  const results: { [name: string]: unknown } = {}
+
+  const addResult = (name: string) => {
+    results[name] = copycat[name]('foo')
+  }
+
+  Object.keys(copycat).forEach(addResult)
+  ;(expect(readmeSource) as any).toHaveUpToDateExamples(results)
+})


### PR DESCRIPTION
## Video with context
https://www.loom.com/share/5803afd0658e444a96e0ca9e52dc5f3e

## Problem
We currently don't know if our readme includes incorrect or outdated code examples for api methods. For example, if the implementation of one of the methods changed such that a different result is returned.

## Solution
In tests, run the api methods with an input of `'foo'`, and check whether this value exists in the readme.

This is a small simple thing, ideally we'd have something like `yarn test -u` in the long run, but that is considerably more work (parse readme, run code examples, write outputs).

## Gotchas
* Won't work if there are multiple calls to an api method, and one of them is incorrect but the others are not
* Assumes we'd always have at least one code example for an api method with the value `'foo'`

I like that we're at least catching the outdated examples now, but I know this solution isn't a very robust one. Maybe we can see how it goes, and go back to the drawing board if its not working out well enough.