### PR TITLE
Use commonjs as built module format

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "scripts": {
     "build": "yarn build:js && yarn build:types",
-    "build:js": "esbuild src/**.ts --platform=node --target=node14 --outdir=dist",
+    "build:js": "esbuild src/**.ts --platform=node --target=node14 --outdir=dist --format=cjs",
     "build:types": "tsc --build --verbose",
     "test": "jest src"
   }


### PR DESCRIPTION
To get it working with snaplet and transformations.

 ## Context
It would be ideal if we could use esm modules. There are a few problems with getting snaplet working with this right now unfortunately:
* jest doesn't appear to be understanding the esm modules, despite us specifying `"type": "module"` in our `package.json` (according to jests docs, they should be leveraging node's native esm module support in this case: https://jestjs.io/docs/ecmascript-modules)
> Beyond that, we attempt to follow node's logic for activating "ESM mode" (such as looking at type in package.json or .mjs files), see their docs for details.
* Our current transpilation in snaplet turns esm imports and exports in common js. As a result, we end up `require`-ing copycat. Since this means we'd be `require`-ing esm moduels, this doesn't end up working. We'd need to change our transpilation configuration here to solve this one.
* We use vm2 for our `transformations.js`, which is expecting commonjs only. We'd need to investigate if and how we can get vm2 to work with esm modules.

So at least for now, it makes more sense to start with commonjs until we've solved these hurdles.

Long term, we may also want to consider having both esm and cjs outputs and configuring our `package.json` accordingly, in case people need one or the other. I have a feeling we'll need this - native esm is great but still quite new to expect people to be on it to use our library. That said, also happy to wait for input from people before making such a change if that would be more sensible.

Totally happy to discuss this though, and there could easily be solutions I'm not thinking of or that I don't know about.