### PR TITLE
Reorder API docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,83 @@ Note that unlike `JSON.stringify()`, object property ordering is not considered.
 
 A re-export of the exports of [`@faker-js/faker`](https://github.com/faker-js/faker) as an object. We do not alter faker in any way, and do not seed it.
 
+### `oneOf(input, values)`
+
+Takes in an [`input`](#input) value and an array of `values`, and returns an item in `values` that corresponds to that `input`:
+
+```js
+oneOf('foo', ['red', 'green', 'blue'])
+// => 'red'
+```
+
+### `int(input[, options])`
+
+Takes in an [`input`](#input) value and returns an integer.
+
+```js
+int('foo')
+// => 2196697842
+```
+
+#### `options`
+
+- **`min=0` and `max=Infinity`:** the minimum and maximum possible values for returned numbers
+
+### `bool(input)`
+
+Takes in an [`input`](#input) value and returns a boolean.
+
+```js
+bool('foo')
+// => false
+```
+
+### `float(input[, options])`
+
+Takes in an [`input`](#input) value and returns a number value with both a whole and decimal segment.
+
+```js
+float('foo')
+// => 2566716916.329745
+```
+
+### `char(input)`
+
+Takes in an [`input`](#input) value and returns a string with a single character.
+
+```js
+char('foo')
+// => 'M'
+```
+
+The generated character will be an alphanumeric: lower and upper case ASCII letters and digits 0 to 9.
+
+#### `options`
+
+- **`min=0` and `max=Infinity`:** the minimum and maximum possible values for returned numbers
+
+### `dateString(input[, options])`
+
+Takes in an [`input`](#input) value and returns a string representing a date in [ISO 8601](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString) format.
+
+```js
+dateString('foo')
+// => '1982-07-11T18:47:39.000Z'
+```
+
+#### `options`
+
+- **`minYear=1980` and `maxYear=2019`:** the minimum and maximum possible year values for returned dates
+
+### `uuid(input)`
+
+Takes in an [input](#input) and returns a string value resembling a [uuid](https://en.wikipedia.org/wiki/Universally_unique_identifier).
+
+```js
+copycat.uuid('foo')
+// => '540b95dd-98a2-56fe-9c95-6e7123c148ca'
+```
+
 ### `email(input)`
 
 Takes in an [input](#input) and returns a string value resembling an email address.
@@ -116,15 +193,6 @@ Takes in an [input](#input) and returns a string value resembling a username.
 ```js
 copycat.username('foo')
 // => 'Zakary.Block356'
-```
-
-### `uuid(input)`
-
-Takes in an [input](#input) and returns a string value resembling a [uuid](https://en.wikipedia.org/wiki/Universally_unique_identifier).
-
-```js
-copycat.uuid('foo')
-// => '540b95dd-98a2-56fe-9c95-6e7123c148ca'
 ```
 
 ### `city(input)`
@@ -171,65 +239,6 @@ copycat.postalAddress('foo')
 // => '178 Adaline Forge, Moreno Valley 8538, Haiti'
 ```
 
-### `int(input[, options])`
-
-Takes in an [`input`](#input) value and returns an integer.
-
-```js
-int('foo')
-// => 2196697842
-```
-
-#### `options`
-
-- **`min=0` and `max=Infinity`:** the minimum and maximum possible values for returned numbers
-
-### `bool(input)`
-
-Takes in an [`input`](#input) value and returns a boolean.
-
-```js
-bool('foo')
-// => false
-```
-
-### `float(input[, options])`
-
-Takes in an [`input`](#input) value and returns a number value with both a whole and decimal segment.
-
-```js
-float('foo')
-// => 2566716916.329745
-```
-
-#### `options`
-
-- **`min=0` and `max=Infinity`:** the minimum and maximum possible values for returned numbers
-
-### `dateString(input[, options])`
-
-Takes in an [`input`](#input) value and returns a string representing a date in [ISO 8601](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString) format.
-
-```js
-dateString('foo')
-// => '1982-07-11T18:47:39.000Z'
-```
-
-#### `options`
-
-- **`minYear=1980` and `maxYear=2019`:** the minimum and maximum possible year values for returned dates
-
-### `char(input)`
-
-Takes in an [`input`](#input) value and returns a string with a single character.
-
-```js
-char('foo')
-// => 'M'
-```
-
-The generated character will be an alphanumeric: lower and upper case ASCII letters and digits 0 to 9.
-
 ### `word(input)`
 
 Takes in an [`input`](#input) value and returns a string value resembling a fictitious word.
@@ -264,12 +273,4 @@ Takes in an [`input`](#input) value and returns a string value resembling a para
 ```js
 paragraph('foo')
 // => 'Vakochiko ke rako kimuvachi hayuso mi vako kaichina, mishi mukaimo hakin va racea. Raechime miko kaimo keki shi navi makin yomehyha, na hya nano kin yokimo rae ra. Ke chi kakinaki kakorae machi. Raeva ka kaiko muvani ka racea kaichiyuchi muvinota, sokaiyu komechino shiso yuha raeraceaki kin chitavi. Kokaiashi chirako rae muyo vachi mukani nakoyuta kinmochikai, muhamuva hy mayushita ke shimo takinka notavi kinvayo.'
-```
-### `oneOf(input, values)`
-
-Takes in an [`input`](#input) value and an array of `values`, and returns an item in `values` that corresponds to that `input`:
-
-```js
-oneOf('foo', ['red', 'green', 'blue'])
-// => 'red'
 ```


### PR DESCRIPTION
I tried order them based on what would be best for users to see first when browsing the docs: so first the most important ones for building richer composite types (e.g, oneOf, int), then very common ones (e.g, uuid, email), then lastly ones that collectively end up taking up more reading space because they are related types (e.g. city+country+streetName+streetAddress+postalAddress, word+words+sentence+paragraph).

Categorisation with headings is also an option, if anyone has ideas. Open to any suggestions.