### PR TITLE
Allow for null input in scramble()

### DIFF
--- a/src/scramble.ts
+++ b/src/scramble.ts
@@ -16,9 +16,10 @@ const CHAR_RANGES_TO_MAKERS: [[number, number], (input: Input) => string][] = [
 const FALLBACK_MAKER = char.inRanges([char.ascii, char.latin1])
 
 export const scramble = (
-  input: string,
+  input: string | null,
   options: ScrambleOptions = {}
 ): string => {
+  input ||= ''
   const { preserve = [' '] } = options
   const preserveSet = new Set(preserve)
 

--- a/src/scramble.ts
+++ b/src/scramble.ts
@@ -15,11 +15,14 @@ const CHAR_RANGES_TO_MAKERS: [[number, number], (input: Input) => string][] = [
 
 const FALLBACK_MAKER = char.inRanges([char.ascii, char.latin1])
 
-export const scramble = (
-  input: string | null,
+export const scramble = <Input extends string | null>(
+  input: Input,
   options: ScrambleOptions = {}
-): string => {
-  input ||= ''
+): Input => {
+  if (typeof input !== 'string') {
+    return input
+  }
+
   const { preserve = [' '] } = options
   const preserveSet = new Set(preserve)
 
@@ -37,7 +40,7 @@ export const scramble = (
     }
   }
 
-  return result
+  return result as Input
 }
 
 const findMatchingMaker = (char: string): ((input: Input) => string) => {


### PR DESCRIPTION
Allow for `scramble(null)` (in which case we'd return `null`).

This begs the question - why not have the null checking happen outside of `scramble()`, rather than have `scramble()` need to know?

The use case I have in mind is quite specific to snaplet itself: it isn't uncommon for us to get `null` values for a particular column value in our transform config. In these cases, it makes for awkward code to need to check for nulls each time, for example, imagine:

```ts
const config: Transform = () => ({
  public: {
    actor({ row }) {
      return {
        first_name: row.first_name === null ? null : copycat.scramble(row.first_name),
        last_name: row.last_name === null ? null : copycat.scramble(row.last_name),
      };
    },

    address({ row }) {
      return {
        address: row.address === null ? null : copycat.scramble(row.address),
        address2: row.address2 === null ? null : copycat.scramble(row.address2),
        district: row.district === null ? null : copycat.scramble(row.district),
        phone: row.phone === null ? null : copycat.scramble(row.phone),
        postal_code: row.postal_code === null ? null : copycat.scramble(row.postal_code, {
          preserve: ["#", "-"],
        }),
      };
    },

    category({ row }) {
      return {
        name: row.name === null ? null : copycat.scramble(row.name),
      };
    },

    city({ row }) {
      return {
        city: row.city === null ? null : copycat.scramble(row.city),
      };
    },

    country({ row }) {
      return {
        country: row.country === null ? null : copycat.scramble(row.country),
      };
    },

    customer({ row }) {
      return {
        email: row.email === null ? null : copycat.scramble(row.email, {
          preserve: ["@", "."], }),
        first_name: row.first_name === null ? null : copycat.scramble(row.first_name),
        last_name: row.last_name === null ? null : copycat.scramble(row.last_name),
      };
    },

    film({ row }) {
      return {
        title: row.title === null ? null : copycat.scramble(row.title),
      };
    },

    language({ row }) {
      return {
        name: row.name === null ? null : copycat.scramble(row.name),
      };
    },

    R({ row }) {
      return {
        email: row.email === null : copycat.scramble(row.email, {
          preserve: ["@", "."],
        }),
        name: row.name === null ? null : copycat.fullName(row.name),
      };
    },

    staff({ row }) {
      return {
        email: row.email === null ? null : copycat.scramble(row.email, {
          preserve: ["@", "."],
        }),
        first_name: row.first_name === null ? null : copycat.scramble(row.first_name),
        last_name: row.last_name === null ? null : copycat.scramble(row.last_name),
        password: row.password === null ? null : copycat.scramble(row.password, {
          preserve: [],
        }),
        username: row.username === null ? null : copycat.scramble(row.username),
      };
    },

    User({ row }) {
      return {
        email: row.email === null ? null : copycat.email(row.email),
        name: row.name === null ? null : copycat.fullName(row.name),
      };
    },
  },
});
```

Happy to discuss alternatives though!