### PR TITLE
Change scramble() to generate safer characters

### DIFF
--- a/src/scramble.test.ts
+++ b/src/scramble.test.ts
@@ -2,7 +2,7 @@ import { copycat } from '.'
 
 test('scrambling', () => {
   expect(copycat.scramble('the DOG ate the cheese!')).toMatchInlineSnapshot(
-    `"xeh ABC agf mom usckyc'"`
+    `"xeh ABC agf mom usckycP"`
   )
 
   expect(copycat.scramble('99 red balloons')).toMatchInlineSnapshot(
@@ -14,4 +14,10 @@ test('preserving chars', () => {
   expect(
     copycat.scramble('foo@bar.org', { preserve: ['@', '.'] })
   ).toMatchInlineSnapshot(`"oxb@fmc.ahs"`)
+})
+
+test('special chars', () => {
+  expect(
+    copycat.scramble('foo-bar_baz+quux@corge.org', { preserve: ['@', '.'] })
+  ).toMatchInlineSnapshot(`"wcirsqgecrsSpmwy@evkbl.gzn"`)
 })

--- a/src/scramble.ts
+++ b/src/scramble.ts
@@ -6,11 +6,20 @@ interface ScrambleOptions {
 
 const codeOf = (x: string) => x.charCodeAt(0)
 
+const safeSpecialChars = '-_+'.split('').map(codeOf)
+
+const safeAscii = char.inRanges([
+  char.lower,
+  char.upper,
+  char.digit,
+  ...safeSpecialChars.map((code): [number, number] => [code, code]),
+])
+
 const CHAR_RANGES_TO_MAKERS: [[number, number], (input: Input) => string][] = [
   [[codeOf('a'), codeOf('z')], char.lower],
   [[codeOf('A'), codeOf('Z')], char.upper],
   [[codeOf('0'), codeOf('9')], char.digit],
-  [[0x20, 0x7e], char.ascii],
+  [[0x20, 0x7e], safeAscii],
 ]
 
 const FALLBACK_MAKER = char.inRanges([char.ascii, char.latin1])


### PR DESCRIPTION
 ## Problem
`scramble()` currently replaces non-alphanumeric ascii characters with different ascii character. The problem with this, is that the replacement character could cause the string to no longer be valid. For example:
* If we scramble an email, we often end up including urls that are not valid in an email address
* If we scramble a url that has encoded chars, we often end up making that url unsafe

 ## Solution
As a simple solution for now: when replacing non-alphanumeric ascii characters, use a range of characters that is generally safer (e.g. for emails and urls): alpha-numeric characters, or one of `-`, `_`, `+`.

We could always have more specific scramble functions in the future (e.g. `copycat.scramble.email()` or `copycat.scramble.url()`), but at least for now, I think it would be helpful to use a more conservative replacement character range for the general case.

The one caveat I can think of, is that the output range is narrower than the input range, so the outputs will be less unique. As far as collisions go, I've been meaning to investigate how likely collisions are more generally for copycat, planning on finding out more about this then.