### PR TITLE
Specify path of bundled types

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "url": "git+https://github.com/snaplet/copycat.git"
   },
   "license": "MIT",
+  "types": "dist/index.d.ts",
   "dependencies": {
     "@faker-js/faker": "^6.2.0",
     "fictional": "^0.4.15",


### PR DESCRIPTION
![Screenshot 2022-08-26 at 11 54 54](https://user-images.githubusercontent.com/39437696/186878915-525ea363-6ea1-42e3-8d96-de78e59671fd.png)

Define path of bundled type files. This will make it possible to fetch type declarations using https://unpkg.com/.