### PR TITLE
feat: Implements fictional's someOf primitive

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,14 @@ copycat.oneOf('foo', ['red', 'green', 'blue'])
 // => 'red'
 ```
 
+### `copycat.someOf(input, range, values)`
+
+Takes in an [`input`](#input) value and an array of `values`, repeatedly picks items from that array a number of times within the given range that corresponds to that `input`. Each item will be picked no more than once.
+
+```js
+copycat.someOf('foo', [1,2], ['paper', 'rock'])
+// => [ 'paper', 'rock' ]
+```
 
 ### `copycat.int(input[, options])`
 

--- a/src/copycat.test.ts
+++ b/src/copycat.test.ts
@@ -312,6 +312,44 @@ test('generated values', () => {
         "Rakomia korayu kovia miyumi yu.",
         "Rakorako raviko viaso ko sorasoyu rayuso yuaviyu, vi soravi raso viyuso yu visoa yuakomi ko.",
       ],
+      "someOf": Array [
+        Array [
+          "paper",
+        ],
+        Array [
+          "rock",
+          "paper",
+        ],
+        Array [
+          "scissors",
+          "rock",
+        ],
+        Array [
+          "rock",
+          "paper",
+        ],
+        Array [
+          "scissors",
+          "rock",
+        ],
+        Array [
+          "rock",
+        ],
+        Array [
+          "paper",
+          "rock",
+        ],
+        Array [
+          "rock",
+        ],
+        Array [
+          "paper",
+        ],
+        Array [
+          "paper",
+          "rock",
+        ],
+      ],
       "streetAddress": Array [
         "246 Fabian Mountains",
         "816 Block Harbors",

--- a/src/primitives.ts
+++ b/src/primitives.ts
@@ -3,12 +3,12 @@ import { Input } from './types'
 
 export const int = fictional.int.options({
   min: 0,
-  max: Number.MAX_SAFE_INTEGER
+  max: Number.MAX_SAFE_INTEGER,
 })
 
 export const float = fictional.float.options({
   min: 0,
-  max: Number.MAX_SAFE_INTEGER
+  max: Number.MAX_SAFE_INTEGER,
 })
 
 export const bool = fictional.bool
@@ -31,6 +31,8 @@ export const sentence = fictional.sentence.options({ unicode: false })
 export const paragraph = fictional.paragraph.options({ unicode: false })
 
 export const oneOf = fictional.oneOf
+
+export const someOf = fictional.someOf
 
 export const times = fictional.times
 

--- a/src/testutils.ts
+++ b/src/testutils.ts
@@ -14,6 +14,8 @@ export const TRANSFORMATIONS: {
   ...{
     times: (input: Input) => copycat.times(input, [4, 5], copycat.word),
     oneOf: (input: Input) => copycat.oneOf(input, ['red', 'green', 'blue']),
+    someOf: (input: Input) =>
+      copycat.someOf(input, [1, 2], ['rock', 'paper', 'scissors']),
     scramble: (input: Input) => copycat.scramble(copycat.fullName(input)),
   },
 }


### PR DESCRIPTION
This PR implement's fictional's `someOf` which:

> Takes in an identifying input value and an array of values, repeatedly picks items from that array a number of times within the given range. Each item will be picked no more than once.

```
someOf('id-23', [1, 2], ['red', 'green', 'blue'])
// =>
[
  'green'
]
```

This is useful when seeding string arrays seen here as `tags` in Prisma models like:

```
model Post {
  id        Int      @id @default(autoincrement())
  title     String
  content   String
  tags      String[]
}
```

While the following `oneOf` can be performed:

`copycat.oneOf([`tech`, `life`, `music`, `art`, `science`]),`

There was no way in copycat to make an array like `['tech', 'art']`.

The `someOf` function now lets you generate deterministic collections.