### PR TITLE
fix: support scrambling negative numbers

### DIFF
--- a/src/scramble.test.ts
+++ b/src/scramble.test.ts
@@ -25,6 +25,7 @@ test('special chars', () => {
 test('numbers', () => {
   expect(copycat.scramble(999999999)).toMatchInlineSnapshot(`633557189`)
   expect(copycat.scramble(782364.902374)).toMatchInlineSnapshot(`773673.271189`)
+  expect(copycat.scramble(-12345.6789)).toMatchInlineSnapshot(`-69254.7142`)
 })
 
 test('dates', () => {

--- a/src/scramble.ts
+++ b/src/scramble.ts
@@ -141,6 +141,6 @@ const scrambleTimeSegment = (input: number) => scrambleNumber(input) % 60
 const scrambleNumber = (input: number, options?: ScrambleOptions): number =>
   +scrambleString(input.toString(), {
     ...options,
-    preserve: ['.'],
+    preserve: ['.', '-'],
     charMaps: [[digitRange, char.inRanges([nonZeroDigitRange])]],
   })


### PR DESCRIPTION
Currently, `copycat.scramble(-123)` will return `NaN` because the `-` is converted into, for example, a `"g"`.

I think this is unexpected and undesirable behaviour, especially when used with snaplet, as a typical use case is:

```ts
// ...
a_number_column: copycat.scramble(row.a_number_column),
// ...
```

Which will work when `row.a_number_column` is positive, but not when it is negative.
The work around would be to manually convert all your numbers to strings, then add `"-"` to the `preserve` options, then cast it back to the appropriate number type, but obviously that's not fun.