### PR TITLE
feat: Support domain option for copycat.email()

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,12 @@ copycat.email('foo')
 #### `options`
 
 - **`limit`:** Constrain generated values to be less than or equal to `limit` number of chars
+- **`domain`:** Constrain the generated email addresses to use the given `domain`
+
+```js
+copycat.email('foo', { domain: 'acme.org' })
+// => 'Albin_Schneider56223@acme.org'
+```
 
 ### `copycat.firstName(input)`
 

--- a/src/copycat.test.ts
+++ b/src/copycat.test.ts
@@ -336,6 +336,18 @@ test('generated values', () => {
         Array [],
         Array [],
       ],
+      "state": Array [
+        "Massachusetts",
+        "Vermont",
+        "South Dakota",
+        "Kansas",
+        "Alaska",
+        "Tennessee",
+        "Hawaii",
+        "Utah",
+        "Washington",
+        "Maryland",
+      ],
       "streetAddress": Array [
         "88 McClure Parks",
         "195 Gutmann Pines",

--- a/src/email.test.ts
+++ b/src/email.test.ts
@@ -5,3 +5,9 @@ import { checkGeneratedValue } from './testutils'
 test('generating fake emails', () => {
   checkGeneratedValue(isEmail, copycat.email)
 })
+
+test('custom domains', () => {
+  expect(copycat.email('foo', { domain: 'acme.org' }).split('@')[1]).toEqual(
+    'acme.org'
+  )
+})

--- a/src/email.ts
+++ b/src/email.ts
@@ -11,6 +11,7 @@ import { Input } from './types'
 
 interface EmailOptions {
   limit?: number
+  domain?: string
 }
 
 const emailifyName = (s: string) => s.replace(/[^A-Za-z]/g, '_')
@@ -45,9 +46,13 @@ export const email = (input: Input, options: EmailOptions = {}): string =>
         max: 99999,
       }),
       '@',
-      oneOf(domainNameSegments),
-      '.',
-      oneOfString(locales.internet.domain_suffix),
+      ...(options.domain
+        ? [options.domain]
+        : [
+            oneOf(domainNameSegments),
+            '.',
+            oneOfString(locales.internet.domain_suffix),
+          ]),
     ],
     options
   )


### PR DESCRIPTION
Constrain the generated email addresses to use a given `domain`:

```js
copycat.email('foo', { domain: 'acme.org' })
// => 'Albin_Schneider56223@acme.org'
```