### PR TITLE
fix(phoneNumber): reduce collisions likeliness

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,7 +350,7 @@ Takes in an [input](#input) and returns a string value resembling a [phone numbe
 
 ```js
 copycat.phoneNumber('foo')
-// => '+18312203332869'
+// => '+208438699696662'
 ```
 
 **note** The strings _resemble_ phone numbers, but will not always be valid. For example, the country dialing code may not exist, or for a particular country, the number of digits may be incorrect. Please let us know if you need valid

--- a/src/phoneNumber.ts
+++ b/src/phoneNumber.ts
@@ -1,7 +1,4 @@
-import { join, char, times } from 'fictional'
+import { int } from 'fictional'
 
-export const phoneNumber = join('', [
-  '+',
-  times([2, 3], char.digit),
-  times([10, 12], char.digit),
-])
+export const phoneNumber = (input: string) =>
+  `+${int(input, { min: 10000000000, max: 999999999999999 })}`


### PR DESCRIPTION
After investigating the use of both `join` and `times` was significantly worsening the algorithm in terms of collisions chances.

Over testing with this script:

```js
const { copycat } = require('../dist/index')
const { v4: uuid } = require('uuid')

const transform = copycat.phoneNumber
const MAX_N = process.env.MAX_N ?? 999999

async function main() {
  const results = new Set()
  for (let i = 0; i < MAX_N; i++) {
    const result = transform(i)
    if (!results.has(result)) {
      results.add(result)
    } else {
      console.log('collision: ', result, ' ', i)
      return
    }
  }
}


main()
```

```
MAX_N=4294967295 node ./scripts/collisionsBasic.js
```

This was resulting in first collisions raising up around ~80-120K iterations.

With this new version, the same script did hit the `Set max length` (4M+ operations) everytime.

BREAKING CHANGES: This will alter older phoneNumbers values


@justinvdm what should be the release process for copycat breaking change release?