### PR TITLE
feat: add options to phone number

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,9 +352,18 @@ Takes in an [input](#input) and returns a string value resembling a [phone numbe
 copycat.phoneNumber('foo')
 // => '+208438699696662'
 ```
+```js
+copycat.phoneNumber('foo', { prefixes: ['+3319900', '+3363998'], min: 1000, max: 9999 })
+// => '+33639983457'
+```
 
 **note** The strings _resemble_ phone numbers, but will not always be valid. For example, the country dialing code may not exist, or for a particular country, the number of digits may be incorrect. Please let us know if you need valid
 phone numbers, and feel free to contribute :)
+
+#### `options`
+- **`min=10000000000`:** Constrain generated values to be greater than or equal to `min` allow to control the minimum number of digits in the phone number
+- **`max=999999999999999`:** Constrain generated values to be less than or equal to `max` allow to control the maximum number of digits in the phone number
+- **`prefixes`:** An array of strings that should be used as prefixes for the generated phone numbers. Allowing to control the country dialing code.
 
 ### `copycat.username(input)`
 

--- a/scripts/collisionsBasic.js
+++ b/scripts/collisionsBasic.js
@@ -1,0 +1,26 @@
+const { v4: uuid } = require('uuid')
+
+const { TRANSFORMATIONS } = require('../dist/testutils')
+
+const METHOD = process.env.METHOD ? process.env.METHOD : 'phoneNumber'
+const MAX_N = +(process.env.MAX_N ?? 999999)
+
+function main() {
+  let firstColision = null
+  let colisions = 0
+  const colide = new Set()
+  for (let i = 0; i < MAX_N; i++) {
+    const result = TRANSFORMATIONS[METHOD](uuid())
+    if (colide.has(result)) {
+      colisions++
+      if (firstColision == null) {
+        firstColision = i
+      }
+    } else {
+      colide.add(result)
+    }
+  }
+  console.log(`firstColision: ${firstColision} colided ${colisions} times`)
+}
+
+main()

--- a/scripts/collisionsBasic.js
+++ b/scripts/collisionsBasic.js
@@ -1,6 +1,10 @@
 const { v4: uuid } = require('uuid')
+const {copycat, fictional} = require('../dist/index')
 
-const { TRANSFORMATIONS } = require('../dist/testutils')
+const TRANSFORMATIONS = {
+  ...fictional,
+  ...copycat,
+}
 
 const METHOD = process.env.METHOD ? process.env.METHOD : 'phoneNumber'
 const MAX_N = +(process.env.MAX_N ?? 999999)

--- a/src/phoneNumber.ts
+++ b/src/phoneNumber.ts
@@ -1,4 +1,68 @@
-import { int } from 'fictional'
+import { int, oneOf } from 'fictional'
+import { Input } from './types'
 
-export const phoneNumber = (input: string) =>
-  `+${int(input, { min: 10000000000, max: 999999999999999 })}`
+type PhoneNumberOptions = {
+  /**
+   * An array of prefixes to use when generating a phone number.
+   * Can be used to generate a fictional phone number instead of a random one.
+   * Using fictional phone numbers might make the generation slower. And might increase likelihood of collisions.
+   * @example
+   * ```ts
+   * phoneNumber(seed, {
+   *   // Generate a French phone number within fictional phone number delimited range (cf: https://en.wikipedia.org/wiki/Fictitious_telephone_number)
+   *   prefixes: ['+3319900', '+3326191', '+3335301'],
+   *   // A french phone number is 11 digits long (including the prefix) so there is no need to generate a number longer than 4 digits
+   *   min: 1000, max: 9999
+   * })
+   * ```
+   * @example
+   *
+   * ```ts
+   * phoneNumber(seed, {
+   *   // Generate a New Jersey fictional phone number
+   *   prefixes: ['+201555'],
+   *   min: 1000, max: 9999
+   * })
+   * ```
+   * @default undefined
+   */
+  prefixes?: Array<string>
+  /**
+   * The minimum number to generate.
+   * @default 10000000000
+   */
+  min?: number
+  /**
+   * The maximum number to generate.
+   * @default 999999999999999
+   */
+  max?: number
+}
+
+export const phoneNumber = (
+  input: Input,
+  options: PhoneNumberOptions = { min: 10000000000, max: 999999999999999 }
+) => {
+  // Use provided min and max, or default values if not provided
+  const min = options.min ?? 10000000000
+  const max = options.max ?? 999999999999999
+
+  if (options.prefixes) {
+    const prefix =
+      options.prefixes.length > 1
+        ? // If multiple prefixes are provided, pick one deterministically
+          oneOf(input, options.prefixes)
+        : options.prefixes[0]
+    const prefixLength = prefix.length
+
+    // Adjust min and max based on prefix length to keep a valid number of digits in the phone number
+    const adjustedMin = Math.max(min, 10 ** (10 - prefixLength))
+    const adjustedMax = Math.min(max, 10 ** (15 - prefixLength) - 1)
+    return `${prefix}${int(input, {
+      min: adjustedMin,
+      max: adjustedMax,
+    })}`
+  }
+
+  return `+${int(input, { min, max })}`
+}


### PR DESCRIPTION
Add more options to `copycat.phoneNumber` to:

1. Be able to control generated phone number length
2. Be able to provide invalid prefixes to make sure you won't dial a real phone number by mistake.