### PR TITLE
feat!: Replace phoneNumber {min,max} options with {min,max}Length

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,7 +3,7 @@
   "files.trimTrailingWhitespace": true,
   "editor.formatOnSave": false,
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
+    "source.fixAll.eslint": "explicit"
   },
   "eslint.alwaysShowStatus": false
 }

--- a/README.md
+++ b/README.md
@@ -367,7 +367,7 @@ copycat.phoneNumber('foo')
 ```
 ```js
 copycat.phoneNumber('foo', { prefixes: ['+3319900', '+3363998'], min: 1000, max: 9999 })
-// => '+33639987662'
+// => '+336399884004662'
 ```
 
 **note** The strings _resemble_ phone numbers, but will not always be valid. For example, the country dialing code may not exist, or for a particular country, the number of digits may be incorrect. Please let us know if you need valid

--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ Takes in an [`input`](#input) value and returns a number value with both a whole
 
 ```js
 copycat.float('foo')
-// => 51167487947531.74
+// => 5208378699696662
 ```
 
 ### `copycat.char(input)`

--- a/README.md
+++ b/README.md
@@ -366,16 +366,16 @@ copycat.phoneNumber('foo')
 // => '+208438699696662'
 ```
 ```js
-copycat.phoneNumber('foo', { prefixes: ['+3319900', '+3363998'], min: 1000, max: 9999 })
-// => '+336399884004662'
+copycat.phoneNumber('foo', { prefixes: ['+3319900', '+3363998'], minLength: 11, maxLength: 11 })
+// => '+3363998462'
 ```
 
 **note** The strings _resemble_ phone numbers, but will not always be valid. For example, the country dialing code may not exist, or for a particular country, the number of digits may be incorrect. Please let us know if you need valid
 phone numbers, and feel free to contribute :)
 
 #### `options`
-- **`min=10000000000`:** Constrain generated values to be greater than or equal to `min` allow to control the minimum number of digits in the phone number
-- **`max=999999999999999`:** Constrain generated values to be less than or equal to `max` allow to control the maximum number of digits in the phone number
+- **`minLength=12`:** Constrain generated values have a length greater than or equal to `minLength`
+- **`maxLength=16`:** Constrain generated values to have a length less than or equal to `maxLength`
 - **`prefixes`:** An array of strings that should be used as prefixes for the generated phone numbers. Allowing to control the country dialing code.
 
 ### `copycat.username(input)`

--- a/README.md
+++ b/README.md
@@ -357,7 +357,7 @@ copycat.fullName('foo')
 
 - **`limit`:** Constrain generated values to be less than or equal to `limit` number of chars
 
-### `copycat.phoneNumber(input)`
+### `copycat.phoneNumber(input[, options])`
 
 Takes in an [input](#input) and returns a string value resembling a [phone number](https://en.wikipedia.org/wiki/MSISDN).
 
@@ -366,7 +366,7 @@ copycat.phoneNumber('foo')
 // => '+208438699696662'
 ```
 ```js
-copycat.phoneNumber('foo', { prefixes: ['+3319900', '+3363998'], minLength: 11, maxLength: 11 })
+copycat.phoneNumber('foo', { prefixes: ['+3319900', '+3363998'], length: 11 })
 // => '+3363998462'
 ```
 
@@ -374,9 +374,8 @@ copycat.phoneNumber('foo', { prefixes: ['+3319900', '+3363998'], minLength: 11, 
 phone numbers, and feel free to contribute :)
 
 #### `options`
-- **`minLength=maxLength ?? 12`:** Constrain generated values have a length greater than or equal to `minLength`. If `minLength` is not specified but `maxLength` is, `minLength` is taken as the given `maxLength`. If neither `minLength` or `maxLength` are given, `minLength` defaults to `12`.
-- **`maxLength=minLength ?? 16`:** Constrain generated values to have a length less than or equal to `maxLength`. If `maxLength` is not specified but `minLength` is, `minLength` is taken as the given `maxLength`. If neither `minLength` or `maxLength` are given, `maxLength` defaults to `16`
-- **`prefixes`:** An array of strings that should be used as prefixes for the generated phone numbers. Allowing to control the country dialing code.
+- **`length={ min: 12, max: 16 }: { min: number, max: number } | number`:** Constrain generated values to the given length. If `length` is given as a `number` (e.g. `{ length: 16 })`, the generated values will have exactly this length. If `length` is given as `{ min: number, max: number }` (e.g. `{ length: { min: 12, max: 16 } }`), the generated values will have a length greater than or equal to `min`, and less than or equal to `max` (i.e. `min <= length <= max`)
+- **`prefixes=[]: string[]`:** An array of strings that should be used as prefixes for the generated phone numbers. Allowing to control the country dialing code.
 
 ### `copycat.username(input)`
 

--- a/README.md
+++ b/README.md
@@ -227,8 +227,8 @@ copycat.bool('foo')
 Takes in an [`input`](#input) value and returns a number value with both a whole and decimal segment.
 
 ```js
-copycat.float('foo')
-// => 5208378699696662
+copycat.float('foo', { min: 0, max: 1 })
+// => 0.5782461953370469
 ```
 
 ### `copycat.char(input)`

--- a/README.md
+++ b/README.md
@@ -374,8 +374,8 @@ copycat.phoneNumber('foo', { prefixes: ['+3319900', '+3363998'], minLength: 11, 
 phone numbers, and feel free to contribute :)
 
 #### `options`
-- **`minLength=12`:** Constrain generated values have a length greater than or equal to `minLength`
-- **`maxLength=16`:** Constrain generated values to have a length less than or equal to `maxLength`
+- **`minLength=maxLength ?? 12`:** Constrain generated values have a length greater than or equal to `minLength`. If `minLength` is not specified but `maxLength` is, `minLength` is taken as the given `maxLength`. If neither `minLength` or `maxLength` are given, `minLength` defaults to `12`.
+- **`maxLength=minLength ?? 16`:** Constrain generated values to have a length less than or equal to `maxLength`. If `maxLength` is not specified but `minLength` is, `minLength` is taken as the given `maxLength`. If neither `minLength` or `maxLength` are given, `maxLength` defaults to `16`
 - **`prefixes`:** An array of strings that should be used as prefixes for the generated phone numbers. Allowing to control the country dialing code.
 
 ### `copycat.username(input)`

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
   "scripts": {
     "release": "git checkout next && git pull && git checkout main && git pull && yarn build && yarn publish && git push && git push --tags",
     "build": "yarn clean && git checkout next && git pull && yarn && yarn build:next && git checkout main && yarn && yarn build:main && yarn build:docs",
+    "build:dev": "yarn build:js && yarn build:docs && yarn build:types",
     "build:main": "yarn build:js && yarn build:types",
     "build:next": "yarn build:next:js && yarn build:next:types",
     "build:next:js": "yarn build:main && NODE_ENV=production yarn -s esbuild dist/index.js --bundle --platform=node --external:@faker-js/faker --minify > ./next.js && yarn clean && mkdir -p dist && mv ./next.js ./dist/next.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snaplet/copycat",
-  "version": "2.0.0-rc.1",
+  "version": "2.0.0",
   "description": "",
   "main": "dist/index.js",
   "files": [

--- a/src/phoneNumber.test.ts
+++ b/src/phoneNumber.test.ts
@@ -6,83 +6,77 @@ test('distributes uniformly', () => {
 
   checkEntropy((input: Input) =>
     copycat.phoneNumber(input, {
-      minLength: 9,
-      maxLength: 9,
+      length: 9,
     })
   )
 
   checkEntropy((input: Input) =>
     copycat.phoneNumber(input, {
       prefixes: ['9', '8', '7', '6'],
-      minLength: 9,
-      maxLength: 9,
+      length: 9,
     })
   )
 
   checkEntropy((input: Input) =>
     copycat.phoneNumber(input, {
-      minLength: 2,
-      maxLength: 20,
+      length: { min: 2, max: 20 },
     })
   )
 
   checkEntropy((input: Input) =>
     copycat.phoneNumber(input, {
       prefixes: ['9', '8', '7', '6'],
-      minLength: 2,
-      maxLength: 20,
+      length: { min: 2, max: 20 },
     })
   )
 })
 
-test('ensures number is within {min,max}Length even when prefix given', () => {
+test('ensures number is within {min,max} length when prefix given', () => {
   const ranges = [
     [9, 9],
     [2, 3],
     [2, 20],
   ]
 
-  for (const [minLength, maxLength] of ranges) {
+  for (const [min, max] of ranges) {
     expectGeneratedValue(
       (result: string) => {
         const len = result.length
-        expect(len).toBeGreaterThanOrEqual(minLength)
-        expect(len).toBeLessThanOrEqual(maxLength)
+        expect(len).toBeGreaterThanOrEqual(min)
+        expect(len).toBeLessThanOrEqual(max)
       },
       (input) =>
         copycat.phoneNumber(input, {
           prefixes: ['9', '8', '7', '6'],
-          minLength,
-          maxLength,
+          length: { min, max },
         })
     )
   }
 })
 
-test('ensures number is within {min,max}Length even when no prefix given', () => {
+test('ensures number is within { min, max } length when no prefix given', () => {
   const ranges = [
     [9, 9],
     [2, 3],
     [2, 20],
   ]
 
-  for (const [minLength, maxLength] of ranges) {
+  for (const [min, max] of ranges) {
     expectGeneratedValue(
       (result: string) => {
         const len = result.length
-        expect(len).toBeGreaterThanOrEqual(minLength)
-        expect(len).toBeLessThanOrEqual(maxLength)
+        expect(len).toBeGreaterThanOrEqual(min)
+        expect(len).toBeLessThanOrEqual(max)
       },
       (input) =>
         copycat.phoneNumber(input, {
-          minLength,
-          maxLength,
+          length: { min, max },
         })
     )
   }
 })
 
-test('defaults maxLength to minLength when not specified', () => {
+test('length as number', () => {
   expectGeneratedValue(
     (result: string) => {
       const len = result.length
@@ -90,20 +84,21 @@ test('defaults maxLength to minLength when not specified', () => {
     },
     (input) =>
       copycat.phoneNumber(input, {
-        minLength: 4,
+        length: 4,
       })
   )
 })
 
-test('defaults minLength to maxLength when not specified', () => {
+test('length as { min, max }', () => {
   expectGeneratedValue(
     (result: string) => {
       const len = result.length
-      expect(len).toBe(4)
+      expect(len).toBeGreaterThanOrEqual(2)
+      expect(len).toBeLessThanOrEqual(20)
     },
     (input) =>
       copycat.phoneNumber(input, {
-        maxLength: 4,
+        length: { min: 2, max: 20 },
       })
   )
 })

--- a/src/phoneNumber.test.ts
+++ b/src/phoneNumber.test.ts
@@ -1,0 +1,83 @@
+import { Input, copycat } from '.'
+import { checkEntropy, expectGeneratedValue } from './testutils'
+
+test('distributes uniformly', () => {
+  checkEntropy((input: Input) => copycat.phoneNumber(input))
+
+  checkEntropy((input: Input) =>
+    copycat.phoneNumber(input, {
+      minLength: 9,
+      maxLength: 9,
+    })
+  )
+
+  checkEntropy((input: Input) =>
+    copycat.phoneNumber(input, {
+      prefixes: ['9', '8', '7', '6'],
+      minLength: 9,
+      maxLength: 9,
+    })
+  )
+
+  checkEntropy((input: Input) =>
+    copycat.phoneNumber(input, {
+      minLength: 2,
+      maxLength: 20,
+    })
+  )
+
+  checkEntropy((input: Input) =>
+    copycat.phoneNumber(input, {
+      prefixes: ['9', '8', '7', '6'],
+      minLength: 2,
+      maxLength: 20,
+    })
+  )
+})
+
+test('ensures number is within min/max even when prefix given', () => {
+  const ranges = [
+    [9, 9],
+    [2, 3],
+    [2, 20],
+  ]
+
+  for (const [minLength, maxLength] of ranges) {
+    expectGeneratedValue(
+      (result: string) => {
+        const len = result.length
+        expect(len).toBeGreaterThanOrEqual(minLength)
+        expect(len).toBeLessThanOrEqual(maxLength)
+      },
+      (input) =>
+        copycat.phoneNumber(input, {
+          prefixes: ['9', '8', '7', '6'],
+          minLength,
+          maxLength,
+        })
+    )
+  }
+})
+
+test('ensures number is within min/max even when no prefix given', () => {
+  const ranges = [
+    [9, 9],
+    [2, 3],
+    [2, 20],
+  ]
+
+  for (const [minLength, maxLength] of ranges) {
+    expectGeneratedValue(
+      (result: string) => {
+        const len = result.length
+        expect(len).toBeGreaterThanOrEqual(minLength)
+        expect(len).toBeLessThanOrEqual(maxLength)
+      },
+      (input) =>
+        copycat.phoneNumber(input, {
+          minLength,
+          maxLength,
+        })
+    )
+  }
+})

--- a/src/phoneNumber.test.ts
+++ b/src/phoneNumber.test.ts
@@ -35,7 +35,7 @@ test('distributes uniformly', () => {
   )
 })
 
-test('ensures number is within min/max even when prefix given', () => {
+test('ensures number is within {min,max}Length even when prefix given', () => {
   const ranges = [
     [9, 9],
     [2, 3],
@@ -59,7 +59,7 @@ test('ensures number is within min/max even when prefix given', () => {
   }
 })
 
-test('ensures number is within min/max even when no prefix given', () => {
+test('ensures number is within {min,max}Length even when no prefix given', () => {
   const ranges = [
     [9, 9],
     [2, 3],
@@ -80,4 +80,30 @@ test('ensures number is within min/max even when no prefix given', () => {
         })
     )
   }
+})
+
+test('defaults maxLength to minLength when not specified', () => {
+  expectGeneratedValue(
+    (result: string) => {
+      const len = result.length
+      expect(len).toBe(4)
+    },
+    (input) =>
+      copycat.phoneNumber(input, {
+        minLength: 4,
+      })
+  )
+})
+
+test('defaults minLength to maxLength when not specified', () => {
+  expectGeneratedValue(
+    (result: string) => {
+      const len = result.length
+      expect(len).toBe(4)
+    },
+    (input) =>
+      copycat.phoneNumber(input, {
+        maxLength: 4,
+      })
+  )
 })

--- a/src/phoneNumber.ts
+++ b/src/phoneNumber.ts
@@ -12,7 +12,8 @@ type PhoneNumberOptions = {
    *   // Generate a French phone number within fictional phone number delimited range (cf: https://en.wikipedia.org/wiki/Fictitious_telephone_number)
    *   prefixes: ['+3319900', '+3326191', '+3335301'],
    *   // A french phone number is 11 digits long (including the prefix) so there is no need to generate a number longer than 4 digits
-   *   min: 1000, max: 9999
+   *   minLength: 4,
+   *   maxLength: 4
    * })
    * ```
    * @example
@@ -21,20 +22,21 @@ type PhoneNumberOptions = {
    * phoneNumber(seed, {
    *   // Generate a New Jersey fictional phone number
    *   prefixes: ['+201555'],
-   *   min: 1000, max: 9999
+   *   minLength: 4,
+   *   maxLength: 4
    * })
    * ```
    * @default undefined
    */
   prefixes?: Array<string>
   /**
-   * The minimum number to generate.
-   * @default 10000000000
+   * Constrain generated values have a length greater than or equal to `minLength`
+   * @default 12
    */
   minLength?: number
   /**
-   * The maximum number to generate.
-   * @default 999999999999999
+   * Constrain generated values to have a length less than or equal to `maxLength`
+   * @default 16
    */
   maxLength?: number
 }
@@ -54,5 +56,6 @@ export const phoneNumber = (input: Input, options: PhoneNumberOptions = {}) => {
   const min = 10 ** (minLength - prefix.length - 1)
   const max = 10 ** (maxLength - prefix.length) - 1
 
+  console.log(min, max)
   return `${prefix}${int(input, { min, max })}`
 }

--- a/src/phoneNumber.ts
+++ b/src/phoneNumber.ts
@@ -1,9 +1,6 @@
 import { int, oneOf } from 'fictional'
 import { Input } from './types'
 
-const DEFAULT_MIN_LENGTH = 12
-const DEFAULT_MAX_LENGTH = 16
-
 type PhoneNumberOptions = {
   /**
    * An array of prefixes to use when generating a phone number.
@@ -14,9 +11,8 @@ type PhoneNumberOptions = {
    * phoneNumber(seed, {
    *   // Generate a French phone number within fictional phone number delimited range (cf: https://en.wikipedia.org/wiki/Fictitious_telephone_number)
    *   prefixes: ['+3319900', '+3326191', '+3335301'],
-   *   // A french phone number is 11 digits long (including the prefix) so there is no need to generate a number longer than 4 digits
-   *   minLength: 4,
-   *   maxLength: 4
+   *   // A french phone number is 11 digits long (including the prefix)
+   *   length: 11,
    * })
    * ```
    * @example
@@ -25,29 +21,24 @@ type PhoneNumberOptions = {
    * phoneNumber(seed, {
    *   // Generate a New Jersey fictional phone number
    *   prefixes: ['+201555'],
-   *   minLength: 4,
-   *   maxLength: 4
+   *   length: 4,
    * })
    * ```
    * @default undefined
    */
   prefixes?: Array<string>
   /**
-   * Constrain generated values have a length greater than or equal to `minLength`
-   * @default maxLength ?? 12
+   * Constrain generated values to the given length
+   * @default { min: 12, max: 16 }
    */
-  minLength?: number
-  /**
-   * Constrain generated values to have a length less than or equal to `maxLength`
-   * @default minLength ?? 16
-   */
-  maxLength?: number
+  length?: { min: number; max: number } | number
 }
 
 export const phoneNumber = (input: Input, options: PhoneNumberOptions = {}) => {
   let prefix = '+'
-  const minLength = options.minLength ?? options.maxLength ?? DEFAULT_MIN_LENGTH
-  const maxLength = options.maxLength ?? options.minLength ?? DEFAULT_MAX_LENGTH
+  const { length = { min: 12, max: 16 } } = options
+  const minLength = typeof length === 'number' ? length : length.min
+  const maxLength = typeof length === 'number' ? length : length.max
 
   if (options.prefixes) {
     prefix =

--- a/src/phoneNumber.ts
+++ b/src/phoneNumber.ts
@@ -31,38 +31,28 @@ type PhoneNumberOptions = {
    * The minimum number to generate.
    * @default 10000000000
    */
-  min?: number
+  minLength?: number
   /**
    * The maximum number to generate.
    * @default 999999999999999
    */
-  max?: number
+  maxLength?: number
 }
 
-export const phoneNumber = (
-  input: Input,
-  options: PhoneNumberOptions = { min: 10000000000, max: 999999999999999 }
-) => {
-  // Use provided min and max, or default values if not provided
-  const min = options.min ?? 10000000000
-  const max = options.max ?? 999999999999999
+export const phoneNumber = (input: Input, options: PhoneNumberOptions = {}) => {
+  const { minLength = 12, maxLength = 16 } = options
+  let prefix = '+'
 
   if (options.prefixes) {
-    const prefix =
+    prefix =
       options.prefixes.length > 1
         ? // If multiple prefixes are provided, pick one deterministically
           oneOf(input, options.prefixes)
         : options.prefixes[0]
-    const prefixLength = prefix.length
-
-    // Adjust min and max based on prefix length to keep a valid number of digits in the phone number
-    const adjustedMin = Math.max(min, 10 ** (10 - prefixLength))
-    const adjustedMax = Math.min(max, 10 ** (15 - prefixLength) - 1)
-    return `${prefix}${int(input, {
-      min: adjustedMin,
-      max: adjustedMax,
-    })}`
   }
 
-  return `+${int(input, { min, max })}`
+  const min = 10 ** (minLength - prefix.length - 1)
+  const max = 10 ** (maxLength - prefix.length) - 1
+
+  return `${prefix}${int(input, { min, max })}`
 }

--- a/src/phoneNumber.ts
+++ b/src/phoneNumber.ts
@@ -1,6 +1,9 @@
 import { int, oneOf } from 'fictional'
 import { Input } from './types'
 
+const DEFAULT_MIN_LENGTH = 12
+const DEFAULT_MAX_LENGTH = 16
+
 type PhoneNumberOptions = {
   /**
    * An array of prefixes to use when generating a phone number.
@@ -31,19 +34,20 @@ type PhoneNumberOptions = {
   prefixes?: Array<string>
   /**
    * Constrain generated values have a length greater than or equal to `minLength`
-   * @default 12
+   * @default maxLength ?? 12
    */
   minLength?: number
   /**
    * Constrain generated values to have a length less than or equal to `maxLength`
-   * @default 16
+   * @default minLength ?? 16
    */
   maxLength?: number
 }
 
 export const phoneNumber = (input: Input, options: PhoneNumberOptions = {}) => {
-  const { minLength = 12, maxLength = 16 } = options
   let prefix = '+'
+  const minLength = options.minLength ?? options.maxLength ?? DEFAULT_MIN_LENGTH
+  const maxLength = options.maxLength ?? options.minLength ?? DEFAULT_MAX_LENGTH
 
   if (options.prefixes) {
     prefix =
@@ -56,6 +60,5 @@ export const phoneNumber = (input: Input, options: PhoneNumberOptions = {}) => {
   const min = 10 ** (minLength - prefix.length - 1)
   const max = 10 ** (maxLength - prefix.length) - 1
 
-  console.log(min, max)
   return `${prefix}${int(input, { min, max })}`
 }

--- a/src/testutils.ts
+++ b/src/testutils.ts
@@ -1,5 +1,7 @@
 import { Input } from './types'
 import { copycat } from '.'
+import { v4 as uuidv4 } from 'uuid'
+import { inspect } from 'util'
 
 const EXCLUDED_METHODS = new Set([
   'setHashKey',
@@ -29,6 +31,60 @@ export const TRANSFORMATIONS: {
 
 export const NUM_CHECKS = +(process.env.COPYCAT_NUM_CHECKS || 50)
 
+export const MIN_ENTROPY = 0.98
+
+export const ENTROPY_DATA_SET_SIZE = 1000
+
+export const checkEntropy = <Result>(
+  makerFn: (input: Input) => Result,
+  { minEntropy = MIN_ENTROPY, dataSetSize = ENTROPY_DATA_SET_SIZE } = {}
+) => {
+  const data = []
+  let i = -1
+
+  while (++i < dataSetSize) {
+    data.push(makerFn(uuidv4()))
+  }
+
+  const entropy = measureEntropy(data)
+
+  try {
+    expect(entropy).toBeGreaterThan(minEntropy)
+  } catch (e) {
+    if (e instanceof Error) {
+      e.message = [e.message, '', `Data: ${inspect(data)}`].join('\n')
+    }
+
+    throw e
+  }
+}
+
+export const expectGeneratedValue = <Result>(
+  expectFn: (result: Result) => unknown,
+  makerFn: (input: Input) => Result
+) => {
+  let i = -1
+
+  while (++i < NUM_CHECKS) {
+    const input = uuidv4()
+    const result = makerFn(input)
+    try {
+      expectFn(result)
+    } catch (e) {
+      if (e instanceof Error) {
+        e.message = [
+          e.message,
+          '',
+          `Input: ${input}`,
+          `Output: ${inspect(result)}`,
+        ].join('\n')
+      }
+
+      throw e
+    }
+  }
+}
+
 export const checkGeneratedValue = <Result>(
   predicateFn: (result: Result) => boolean,
   makerFn: (input: Input) => Result
@@ -36,6 +92,39 @@ export const checkGeneratedValue = <Result>(
   let i = -1
 
   while (++i < NUM_CHECKS) {
-    expect(predicateFn(makerFn(i))).toBe(true)
+    const result = makerFn(i)
+    try {
+      expect(predicateFn(result)).toBe(true)
+    } catch (e) {
+      if (e instanceof Error) {
+        e.message = [
+          e.message,
+          '',
+          `Input: ${i}`,
+          `Output: ${inspect(result)}`,
+        ].join('\n')
+      }
+
+      throw e
+    }
   }
+}
+
+export function measureEntropy<V>(data: V[]) {
+  const counts = new Map()
+
+  for (const value of data) {
+    counts.set(value, (counts.get(value) ?? 0) + 1)
+  }
+
+  const probabilities = [...counts.values()].map((count) => count / data.length)
+
+  const entropy = probabilities.reduce(
+    (sum, prob) => sum - prob * Math.log2(prob),
+    0
+  )
+
+  const normalizedEntropy = entropy / Math.log2(data.length)
+
+  return normalizedEntropy
 }

--- a/src/testutils.ts
+++ b/src/testutils.ts
@@ -111,20 +111,27 @@ export const checkGeneratedValue = <Result>(
 }
 
 export function measureEntropy<V>(data: V[]) {
+  // Create a Map to store the counts of each unique value
   const counts = new Map()
 
+  // Count occurrences of each unique value in the data array
   for (const value of data) {
+    // Update the count for the current value
     counts.set(value, (counts.get(value) ?? 0) + 1)
   }
 
+  // Calculate the probability for each unique value
   const probabilities = [...counts.values()].map((count) => count / data.length)
 
+  // Calculate Shannon entropy
   const entropy = probabilities.reduce(
     (sum, prob) => sum - prob * Math.log2(prob),
     0
   )
 
+  // Normalize the entropy to be between 0 and 1
   const normalizedEntropy = entropy / Math.log2(data.length)
 
+  // Return the normalized entropy
   return normalizedEntropy
 }


### PR DESCRIPTION
```ts
// before
copycat.phoneNumber(input, { min: 100000, max: 999999999 })
copycat.phoneNumber(input, { min: 100000000, max: 999999999 })

// after
copycat.phoneNumber(input, { length: { min: 6, max: 9 } })
copycat.phoneNumber(input,  { length: 9 })
```

**BREAKING CHANGES**
* In the cases where the `prefixes` option is provided, copycat will now return a different output for the same input
* The `min` and `max` options have been removed in favour of `length: number | { min: number, max: number }`

 ## TLDR
We discovered bugs in our implementation of `phoneNumber`, and in the process decided that ``length: number | { min: number, max: number }` instead of `{ min: number, max: number }` options would avoid the bugs altogether, while at the same time provide a better UX (more direct way of describing the intent, less room for human error)

 ## Detailed context
 ### Part 1: The original issue
Currently, we support `min` and `max` options for `phoneNumber`, to be used like this:

```ts
copycat.phoneNumber(input, { min: 1000000, max: 9999999 })
```

To support this, for the case where users provided `prefixes` optios also, we had this code:

```
    const adjustedMin = Math.max(min, 10 ** (10 - prefixLength))
    const adjustedMax = Math.min(max, 10 ** (15 - prefixLength) - 1)
```

Consider the case where the given `min` is `100000000` and the given `max` is `999999999` - both of digit length 9. Here, there are two issues:
1. the hardcoded 10 and 15 do not match the lengths of the min and max given, which was 9
2. we're using Math.max() for the adjustedMin

Because of (1) and (2), we end up with an adjustedMin of 1000000000 (the computed value is larger than the users, so it gets taken), and a max of 999999999 (the user's max was used since it was smaller).

Here the max is actually smaller than the min, so we end up clamping the generated values to 1000000000 (i.e, the generated value will always be 1000000000 since it is now both the upper and lower bound).

 ### Part 2: Where the API change comes in

Working on solving the bugs outlined about lead me to try a test case that looks like this:

```ts
copycat.phoneNumber(input, { min: 21, max: 106 })
```

Then I realised that's a weird way to use phone number. What `min` and `max` are really meant to be given as, are values like `100000000` and `999999999`. In other words, they're really just meant for describing the desired min/max _lengths_ of the phone numbers. But then, why not just have the user be able to describe this directly?

```
copycat.phoneNumber(input, { length: { min: 2, max: 10 } })
```

* The user can now express their intent directly
* We're also now giving less opportunity for the API to be used in a way that was not intended (just as I did with `{ min: 21, max: 106 }`)