### PR TITLE
fix: patch fictional package

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "types": "dist/index.d.ts",
   "dependencies": {
     "@faker-js/faker": "^8.4.1",
-    "fictional": "^2.0.2",
+    "fictional": "^2.0.3",
     "string-argv": "^0.3.2",
     "uuid": "^9.0.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1583,7 +1583,7 @@ __metadata:
     eslint-config-prettier: "npm:^9.1.0"
     eslint-plugin-prettier: "npm:^5.1.3"
     fast-stats: "npm:^0.0.6"
-    fictional: "npm:^2.0.2"
+    fictional: "npm:^2.0.3"
     is-email: "npm:^1.0.2"
     is-mac-address: "npm:^1.0.4"
     is-url: "npm:^1.2.4"
@@ -3394,15 +3394,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fictional@npm:^2.0.2":
-  version: 2.0.2
-  resolution: "fictional@npm:2.0.2"
+"fictional@npm:^2.0.3":
+  version: 2.0.3
+  resolution: "fictional@npm:2.0.3"
   dependencies:
     decimal.js: "npm:^10.4.3"
     fast-json-stable-stringify: "npm:^2.1.0"
     fnv-plus: "npm:^1.3.1"
     siphash: "npm:^1.1.0"
-  checksum: 10c0/a21b0cd85333b7e41079c10d41a5f3467290460ea75a6257b9ae1403e6a7ef45b0dc4ede4ca110f2e7d265802c89e37921b46284ff97791f3627b7850e7a70cf
+  checksum: 10c0/d2ce8cfdceeb5ee8fe7294e8b46669d8677dc57cba3a45a2f02e7403e19b7b6d295146caa7c12d1a7d7f420954083aa5f49403495e41f0205f527968170b9252
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Context 
Starting to see this issue when patching to 0.98.0 of snaplet seed, setting a resolution of fictional 2.0.3 fixed the issue but this would also fix the issue without a resolution 
```bash
pnpm db:seed                               ✔  11:05:24  

> create-t3-turbo@ db:seed /Users/hamish.buckmaster/dev/hub
> pnpm -F db seed


> @acme/db@0.1.0 seed /Users/hamish.buckmaster/dev/hub/packages/db
> npx tsx ./seed.ts

/Users/hamish.buckmaster/dev/hub/node_modules/fictional/hash.js:7
var generateKey = siphash.string16_to_key.bind(siphash)
                                          ^

TypeError: Cannot read properties of undefined (reading 'bind')
    at Object.<anonymous> (/Users/hamish.buckmaster/dev/hub/node_modules/fictional/hash.js:7:43)
    at Module._compile (node:internal/modules/cjs/loader:1369:14)
    at Object.transformer (/Users/hamish.buckmaster/.npm/_npx/fd45a72a545557e9/node_modules/tsx/dist/register-C1urN2EO.cjs:2:1122)
    at Module.load (node:internal/modules/cjs/loader:1206:32)
    at Module._load (node:internal/modules/cjs/loader:1022:12)
    at Module.require (node:internal/modules/cjs/loader:1231:19)
    at require (node:internal/modules/helpers:179:18)
    at Object.<anonymous> (/Users/hamish.buckmaster/dev/hub/node_modules/fictional/index.js:1:16)
    at Module._compile (node:internal/modules/cjs/loader:1369:14)
    at Object.transformer (/Users/hamish.buckmaster/.npm/_npx/fd45a72a545557e9/node_modules/tsx/dist/register-C1urN2EO.cjs:2:1122)

Node.js v20.12.0
/Users/hamish.buckmaster/dev/hub/packages/db:
 ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL  @acme/db@0.1.0 seed: 'npx tsx ./seed.ts'
Exit status 1
 ELIFECYCLE  Command failed with exit code 1.
 
```
 
 Downstream: https://github.com/oftherivier/fictional/commit/0d31c11738827fe27438603c8c6ca2823f249e76